### PR TITLE
Updating old instns

### DIFF
--- a/import_dashboards.sh
+++ b/import_dashboards.sh
@@ -15,7 +15,7 @@ PASSWORD=$2
 
 function print_usage {
         printf "\n\n${yel}Usage:${end}\n"
-        printf "\t${cyn}./install_bluecompute_ce.sh <grafana-url> <grafana-admin-password>${end}\n\n"
+        printf "\t${cyn}./import_dashboards.sh <grafana-url> <grafana-admin-password>${end}\n\n"
 }
 
 


### PR DESCRIPTION
The scripts are still using `bx` commands and some instructions does not apply for the latest cloud. These are breaking this tutorial - https://www.ibm.com/cloud/garage/tutorials/microservices-app-on-kubernetes?task=1

Updated those instructions to reflect the new commands.
